### PR TITLE
Fix combining char problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,16 @@ else
 	CFLAGS = -O2 -std=c11
 endif
 
+install_path := /usr/local/bin
+
 all: 
 	$(call msg,TRANS,STARTS-BUILDING)
 	$(Q)cargo build --release
 	$(call msg,TRANS,BUILD-SUCCEED)
 
 install:
-	$(call msg,INSTALL)
-	$(Q)sudo cp ./target/release/transgender /usr/local/bin/transgender
+	$(call msg,INSTALL,$(install_path)/transgender)
+	$(Q)sudo install target/release/transgender $(install_path)
 
 uninstall:
 	$(call msg,UNINSTALL)

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -196,6 +196,7 @@ impl Canvas {
         let write_top: usize = self.height - 1;
         let write_bottom: usize = 0;
 
+        // l_w_l: left window left
         let l_w_l: usize = 0;
         let l_w_r: usize = (self.width / 10 * 6 - 1) as usize;
 
@@ -269,6 +270,7 @@ impl Canvas {
 
         let mut font_len: usize = 0;
         let mut do_preview: bool = false;
+        let mut complement: usize = 0;
 
         for i in 0..self.height {
             let mut j = 0;
@@ -279,7 +281,15 @@ impl Canvas {
                 }
 
                 let len = self.get_utf8_len(self.pixels[i][j]);
-                font_len += len;
+
+                // for a zero-width character such as a combining character, spaces in pixels is
+                // not enough, insert more spaces (complement) for alignment
+                if len == 0 {
+                    font_len += 1;
+                    complement += 1;
+                } else {
+                    font_len += len;
+                }
 
                 //  If the font_len reaches over the capcity of the left side window, discard this
                 //  character and update the preview window.
@@ -299,9 +309,13 @@ impl Canvas {
                         str_to_draw.push(' ');
                     }
 
+                    str_to_draw.push_str(&(0..complement).map(|_| ' ').collect::<String>());
+
                     j = r_w_l;
                     font_len = 0;
+                    complement = 0;
                     do_preview = true;
+
                     continue;
                 }
 
@@ -346,9 +360,12 @@ impl Canvas {
 
                 str_to_draw.push(self.pixels[i][j]);
                 j += 1;
-            }
+            } // loop
+
+            str_to_draw.push_str(&(0..complement).map(|_| ' ').collect::<String>());
 
             font_len = 0;
+            complement = 0;
             do_preview = false;
         }
 

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -79,15 +79,15 @@ impl Canvas {
     /// terminal
     fn get_utf8_len(&self, c: char) -> usize {
         match self.utf8_table.classify(c) {
-            WcWidth::One => return 1,
-            WcWidth::Two => return 2,
-            WcWidth::NonPrint => return 0,
-            WcWidth::Combining => return 0,
-            WcWidth::Ambiguous => return 1,
-            WcWidth::PrivateUse => return 0,
-            WcWidth::Unassigned => return 0,
-            WcWidth::WidenedIn9 => return 2,
-            WcWidth::NonCharacter => return 0,
+            WcWidth::One => 1,
+            WcWidth::Two => 2,
+            WcWidth::NonPrint => 0,
+            WcWidth::Combining => 0,
+            WcWidth::Ambiguous => 1,
+            WcWidth::PrivateUse => 0,
+            WcWidth::Unassigned => 0,
+            WcWidth::WidenedIn9 => 2,
+            WcWidth::NonCharacter => 0,
         }
     }
 


### PR DESCRIPTION
This fixes the combining char's alignment problem, for it lacks spaces to align. However, the black blocks created by the incorrect terminal color code display are not addressed.

<img width="1467" alt="Screenshot 2024-11-22 at 7 30 18 AM" src="https://github.com/user-attachments/assets/332e762a-9328-4c0c-8b70-28498fcbab40">
